### PR TITLE
Fix CSS paths when exporting site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,17 @@
 /** @type {import('next').NextConfig} */
-const repo = 'tes-site'; // your repo name here
-const isProd = process.env.NODE_ENV === 'production';
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? ''
+const isProd = process.env.NODE_ENV === 'production'
 
 const nextConfig = {
   output: 'export',
   images: { unoptimized: true },
   trailingSlash: true,
-  basePath: isProd ? `/${repo}` : '',
-  assetPrefix: isProd ? `/${repo}/` : '',
-};
+  ...(isProd && repo
+    ? {
+        basePath: `/${repo}`,
+        assetPrefix: `/${repo}/`,
+      }
+    : {}),
+}
 
-module.exports = nextConfig;
+module.exports = nextConfig


### PR DESCRIPTION
## Summary
- derive GitHub repository name from `GITHUB_REPOSITORY` environment variable to set `basePath` and `assetPrefix`
- ensure static export uses correct asset paths so CSS loads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895c8b1fd88832496cc7b7229c20379