### PR TITLE
Fix CSS paths when exporting site and add PCB trace background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -29,3 +29,14 @@ body {
 .card {
   @apply border border-neutral-200 dark:border-neutral-800 rounded-2xl p-5;
 }
+@keyframes dashShift { to { stroke-dashoffset: -2000; } }
+
+.trace-animate {
+  animation: dashShift 24s linear infinite;
+  will-change: stroke-dashoffset;
+}
+
+/* reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  .trace-animate { animation: none; }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -12,7 +12,10 @@ export const metadata = {
     description: 'We design embedded systems: PCB design, firmware, connected products.',
     images: ['/og.jpg'],
   },
-  themeColor: '#0a0a0a'
+}
+
+export const viewport = {
+  themeColor: '#0a0a0a',
 }
 
 export default function RootLayout({ children }) {
@@ -21,7 +24,9 @@ export default function RootLayout({ children }) {
       <body>
         <header className="border-b border-neutral-200 dark:border-neutral-800">
           <div className="container flex items-center justify-between py-4">
-            <a href="/" className="font-semibold tracking-tight">TES <span className="text-neutral-500">Tröndle Embedded System</span></a>
+            <a href="/" className="font-semibold tracking-tight">
+              TES <span className="text-neutral-500">Tröndle Embedded System</span>
+            </a>
             <nav className="flex gap-4">
               <a href="/" className="hover:opacity-80">Home</a>
               <a href="/about" className="hover:opacity-80">About</a>

--- a/app/page.js
+++ b/app/page.js
@@ -1,22 +1,27 @@
+import TracesBackground from '../components/TracesBackground'
+
 export default function Page() {
   return (
     <>
-      <section className="py-8">
-        <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">Embedded systems, built right.</h1>
-        <p className="mt-4 max-w-2xl text-neutral-600 dark:text-neutral-300">
-          We design and ship custom electronics: PCB design, firmware, and connected products. From idea to tested prototypes.
-        </p>
-        <div className="mt-6 flex gap-3">
-          <a className="btn btn-primary" href="mailto:hello@tes.swiss">Start a project</a>
-          <a className="btn" href="/portfolio">See work</a>
+      <section className="py-8 relative overflow-hidden rounded-2xl border border-neutral-200 dark:border-neutral-800">
+        <TracesBackground />
+        <div className="relative">
+          <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">Embedded systems, built right.</h1>
+          <p className="mt-4 max-w-2xl text-neutral-600 dark:text-neutral-300">
+            We design and ship custom electronics: PCB design, firmware, and connected products. From idea to tested prototypes.
+          </p>
+          <div className="mt-6 flex gap-3">
+            <a className="btn btn-primary" href="mailto:hello@tes.swiss">Start a project</a>
+            <a className="btn" href="/portfolio">See work</a>
+          </div>
+          <ul className="mt-6 flex flex-wrap gap-2 text-sm text-neutral-500">
+            <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">PCB design (ESP32, STM32, RP2040)</li>
+            <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Firmware (C/C++, Klipper, ESP-IDF)</li>
+            <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Power & thermal design</li>
+            <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Connectivity (Wi‑Fi, BLE, USB, CAN)</li>
+            <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Prototyping & test</li>
+          </ul>
         </div>
-        <ul className="mt-6 flex flex-wrap gap-2 text-sm text-neutral-500">
-          <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">PCB design (ESP32, STM32, RP2040)</li>
-          <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Firmware (C/C++, Klipper, ESP-IDF)</li>
-          <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Power & thermal design</li>
-          <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Connectivity (Wi‑Fi, BLE, USB, CAN)</li>
-          <li className="px-3 py-1 border border-neutral-200 dark:border-neutral-800 rounded-full">Prototyping & test</li>
-        </ul>
       </section>
 
       <section className="border-t border-neutral-200 dark:border-neutral-800 mt-10 pt-10">

--- a/components/TracesBackground.jsx
+++ b/components/TracesBackground.jsx
@@ -1,0 +1,57 @@
+export default function TracesBackground() {
+  const rows = [20, 60, 100, 140, 180, 220, 260, 300]
+  return (
+    <svg
+      className="absolute inset-0 h-full w-full pointer-events-none opacity-40 dark:opacity-30"
+      viewBox="0 0 1200 340"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <defs>
+        {/* soft fade at edges */}
+        <linearGradient id="fadeX" x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stopOpacity="0" />
+          <stop offset="10%" stopOpacity="1" />
+          <stop offset="90%" stopOpacity="1" />
+          <stop offset="100%" stopOpacity="0" />
+        </linearGradient>
+        <linearGradient id="traceGrad" x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.35" />
+          <stop offset="50%" stopColor="currentColor" stopOpacity="0.65" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.35" />
+        </linearGradient>
+      </defs>
+
+      {rows.map((y, i) => (
+        <g key={i} style={{ transform: `translateY(${i * 6}px)` }}>
+          {/* “trace” */}
+          <path
+            d={`M0 ${y} Q 150 ${y - 30}, 300 ${y}
+               T 600 ${y} T 900 ${y} T 1200 ${y}`}
+            fill="none"
+            stroke="url(#traceGrad)"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeDasharray="8 10"
+            className="trace-animate"
+            style={{ animationDuration: `${22 + i * 2}s` }}
+          />
+          {/* via “pads” */}
+          {[150, 300, 450, 600, 750, 900, 1050].map((x, j) => (
+            <circle
+              key={j}
+              cx={x}
+              cy={y}
+              r="2.2"
+              fill="currentColor"
+              opacity="0.35"
+            />
+          ))}
+        </g>
+      ))}
+
+      {/* subtle top/bottom separators */}
+      <rect x="0" y="0" width="1200" height="340" fill="url(#fadeX)" />
+    </svg>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,17 @@
 /** @type {import('next').NextConfig} */
-const repo = 'tes-site'; // your repo name here
-const isProd = process.env.NODE_ENV === 'production';
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? ''
+const isProd = process.env.NODE_ENV === 'production'
 
 const nextConfig = {
   output: 'export',
   images: { unoptimized: true },
   trailingSlash: true,
-  basePath: isProd ? `/${repo}` : '',
-  assetPrefix: isProd ? `/${repo}/` : '',
-};
+  ...(isProd && repo
+    ? {
+        basePath: `/${repo}`,
+        assetPrefix: `/${repo}/`,
+      }
+    : {}),
+}
 
-module.exports = nextConfig;
+module.exports = nextConfig


### PR DESCRIPTION
## Summary
- derive GitHub repository name from `GITHUB_REPOSITORY` environment variable to set `basePath` and `assetPrefix`
- ensure static export uses correct asset paths so CSS loads
- move `themeColor` into `viewport` export to eliminate Next.js warnings
- add animated SVG PCB trace background on homepage with reduced-motion support
- clean up header markup in layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx --no-install next build`


------
https://chatgpt.com/codex/tasks/task_e_6895c8b1fd88832496cc7b7229c20379