### PR TITLE
Add breadcrumb navigation and service/project pages

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -12,7 +12,6 @@ export default function Page() {
           <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">Embedded systems, built right.</h1>
           <p className="mt-4 max-w-2xl text-neutral-600 dark:text-neutral-300">
             We design and ship custom electronics: PCB design, firmware, and connected products. From idea to tested prototypes.
-
           </p>
           <div className="mt-6 flex gap-3">
             <a className="btn btn-primary" href="mailto:hello@tes.swiss">Start a project</a>
@@ -33,43 +32,42 @@ export default function Page() {
       <section className="border-t border-neutral-200 dark:border-neutral-800 mt-10 pt-10">
         <h2 className="text-2xl font-semibold">What we do</h2>
         <div className="grid md:grid-cols-2 gap-6 mt-4">
-          <div className="card">
+          <a className="card" href="/services/pcb-design">
             <h3 className="text-lg font-semibold">Custom PCB design</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">4-layer and compact boards with solid power delivery and signal integrity. From schematic to ready-to-assemble Gerbers.</p>
-          </div>
-          <div className="card">
+          </a>
+          <a className="card" href="/services/firmware">
             <h3 className="text-lg font-semibold">Firmware & integration</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">Drivers, control loops, and connectivity. From bare-metal to RTOS and Home Assistant integrations.</p>
-          </div>
-          <div className="card">
+          </a>
+          <a className="card" href="/services/power">
             <h3 className="text-lg font-semibold">Thermal & power safety</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">PD negotiation, protections, run-away detection, and validated thermal behavior.</p>
-          </div>
-          <div className="card">
+          </a>
+          <a className="card" href="/services/prototyping">
             <h3 className="text-lg font-semibold">Rapid prototyping</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">Bring-up, fixtures, test scripts, and iteration until it’s shippable.</p>
-          </div>
+          </a>
         </div>
       </section>
 
       <section className="mt-10">
         <h2 className="text-2xl font-semibold">Selected highlights</h2>
         <div className="grid md:grid-cols-3 gap-4 mt-4">
-          <article className="card">
+          <a className="card" href="/projects/heated-coaster">
             <h3 className="font-semibold">Smart heated coaster</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">USB‑PD, hall-sensor actuation, PID via ESP32, thermal run‑away protection, Home Assistant.</p>
-          </article>
-          <article className="card">
+          </a>
+          <a className="card" href="/projects/esp32s3-led-bed">
             <h3 className="font-semibold">ESP32‑S3 LED/bed controller</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">Neopixel control with isolated planes, Wi‑Fi, Klipper integration.</p>
-          </article>
-          <article className="card">
+          </a>
+          <a className="card" href="/projects/rc-bms">
             <h3 className="font-semibold">RC module & BMS</h3>
             <p className="text-neutral-600 dark:text-neutral-300 mt-1">Integrated BMS, dual motor control, robust CAN/USB comms.</p>
-          </article>
+          </a>
         </div>
       </section>
     </>
   )
 }
-

--- a/app/portfolio/page.js
+++ b/app/portfolio/page.js
@@ -1,13 +1,14 @@
 export const metadata = { title: 'Portfolio — TES' }
 
-function Project({ title, bullets }) {
+function Project({ title, bullets, href }) {
+  const Tag = href ? 'a' : 'div'
   return (
-    <article className="card">
+    <Tag className="card" {...(href ? { href } : {})}>
       <h3 className="font-semibold">{title}</h3>
       <ul className="list-disc ml-5 mt-2 space-y-1">
         {bullets.map((b, i) => <li key={i}>{b}</li>)}
       </ul>
-    </article>
+    </Tag>
   )
 }
 
@@ -17,28 +18,28 @@ export default function Page() {
       <h1 className="text-4xl font-semibold tracking-tight">Portfolio</h1>
       <p className="mt-3 text-neutral-600 dark:text-neutral-300">Some of the work and experiments we can talk about publicly.</p>
       <div className="grid md:grid-cols-2 gap-4 mt-6">
-        <Project title="Heated Coaster — Smart & Safe" bullets={[
-          "USB‑PD → 24 V with safe negotiation",
-          "Hall‑sensor triggered actuation",
-          "On-board PID using tile thermistor",
-          "Thermal run‑away protection",
-          "ESP32 + Home Assistant integration"
+        <Project href="/projects/heated-coaster" title="Heated Coaster — Smart & Safe" bullets={[
+          'USB‑PD → 24 V with safe negotiation',
+          'Hall‑sensor triggered actuation',
+          'On-board PID using tile thermistor',
+          'Thermal run‑away protection',
+          'ESP32 + Home Assistant integration'
         ]} />
-        <Project title="ESP32‑S3 LED Bed Controller" bullets={[
-          "Neopixel control with power/ground planes",
-          "Wi‑Fi control + Klipper firmware hooks",
-          "4‑layer layout optimized for noise & heat"
+        <Project href="/projects/esp32s3-led-bed" title="ESP32‑S3 LED Bed Controller" bullets={[
+          'Neopixel control with power/ground planes',
+          'Wi‑Fi control + Klipper firmware hooks',
+          '4‑layer layout optimized for noise & heat'
         ]} />
-        <Project title="RC Car Control & BMS Board" bullets={[
-          "Battery management (BQ24075)",
-          "Dual motor driver (e.g., DRV8833)",
-          "ESP32 connectivity, CAN/USB comms",
-          "Robust power path and protections"
+        <Project href="/projects/rc-bms" title="RC Car Control & BMS Board" bullets={[
+          'Battery management (BQ24075)',
+          'Dual motor driver (e.g., DRV8833)',
+          'ESP32 connectivity, CAN/USB comms',
+          'Robust power path and protections'
         ]} />
         <Project title="RFID Filament Detection Concept" bullets={[
-          "NFC/RFID reader integration",
-          "Data model for spool tracking",
-          "Security and encryption experiments"
+          'NFC/RFID reader integration',
+          'Data model for spool tracking',
+          'Security and encryption experiments'
         ]} />
       </div>
       <div className="mt-6">

--- a/app/projects/esp32s3-led-bed/page.js
+++ b/app/projects/esp32s3-led-bed/page.js
@@ -1,0 +1,20 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'ESP32-S3 LED Bed Controller — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/portfolio', label: 'Portfolio' }, { label: 'ESP32-S3 LED Bed Controller' }]} />
+      <h1>ESP32-S3 LED Bed Controller</h1>
+      <p>Neopixel control and Wi-Fi connectivity for LED-lit beds, with Klipper firmware hooks and a four-layer layout optimised for noise and thermal performance.</p>
+      <h2>Highlights</h2>
+      <ul>
+        <li>Neopixel control with power/ground planes</li>
+        <li>Wi-Fi control + Klipper firmware hooks</li>
+        <li>4-layer layout optimized for noise & heat</li>
+      </ul>
+      <p><a href="/portfolio">← Back to portfolio</a></p>
+    </article>
+  )
+}

--- a/app/projects/heated-coaster/page.js
+++ b/app/projects/heated-coaster/page.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'Smart Heated Coaster — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/portfolio', label: 'Portfolio' }, { label: 'Smart Heated Coaster' }]} />
+      <h1>Smart Heated Coaster</h1>
+      <p>USB-PD power with safe negotiation to 24 V, hall-sensor triggered actuation, on-board PID using the tile’s thermistor, thermal run-away protection, and ESP32 + Home Assistant integration.</p>
+      <h2>Highlights</h2>
+      <ul>
+        <li>USB-PD trigger to 24 V (negotiation + protections)</li>
+        <li>Magnetic suspension + hall sensor to detect load</li>
+        <li>PID loop on-board; failsafes & temp limits</li>
+        <li>Firmware OTA + Home Assistant hooks</li>
+      </ul>
+      <p><a href="/portfolio">← Back to portfolio</a></p>
+    </article>
+  )
+}

--- a/app/projects/rc-bms/page.js
+++ b/app/projects/rc-bms/page.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'RC Car Control & BMS Board — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/portfolio', label: 'Portfolio' }, { label: 'RC Car Control & BMS Board' }]} />
+      <h1>RC Car Control & BMS Board</h1>
+      <p>Battery management and dual motor control in a single board, featuring ESP32 connectivity, CAN/USB communications, and a robust protected power path.</p>
+      <h2>Highlights</h2>
+      <ul>
+        <li>Battery management (BQ24075)</li>
+        <li>Dual motor driver (e.g., DRV8833)</li>
+        <li>ESP32 connectivity, CAN/USB comms</li>
+        <li>Robust power path and protections</li>
+      </ul>
+      <p><a href="/portfolio">← Back to portfolio</a></p>
+    </article>
+  )
+}

--- a/app/services/firmware/page.js
+++ b/app/services/firmware/page.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'Firmware & Integration — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/#what-we-do', label: 'What we do' }, { label: 'Firmware & Integration' }]} />
+      <h1>Firmware & Integration</h1>
+      <p>From bare-metal drivers to RTOS-based apps, we deliver firmware optimised for performance and reliability. We also handle integrations with systems like Home Assistant.</p>
+      <h2>Capabilities</h2>
+      <ul>
+        <li>Low-level driver development</li>
+        <li>Control loops & signal processing</li>
+        <li>Wireless connectivity (Wi-Fi, BLE)</li>
+        <li>Integration into existing ecosystems</li>
+      </ul>
+      <p><a href="/#what-we-do">← Back to services</a></p>
+    </article>
+  )
+}

--- a/app/services/pcb-design/page.js
+++ b/app/services/pcb-design/page.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'Custom PCB Design — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/#what-we-do', label: 'What we do' }, { label: 'Custom PCB Design' }]} />
+      <h1>Custom PCB Design</h1>
+      <p>We create reliable, manufacturable PCBs optimised for performance, power delivery, and signal integrity. From 2 to 4+ layers, compact form factors, and careful component selection.</p>
+      <h2>Our process</h2>
+      <ul>
+        <li>Schematic design based on your requirements</li>
+        <li>PCB layout with focus on thermal and EMI performance</li>
+        <li>Gerber and manufacturing output</li>
+        <li>Assembly guidance</li>
+      </ul>
+      <p><a href="/#what-we-do">← Back to services</a></p>
+    </article>
+  )
+}

--- a/app/services/power/page.js
+++ b/app/services/power/page.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'Thermal & Power Safety — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/#what-we-do', label: 'What we do' }, { label: 'Thermal & Power Safety' }]} />
+      <h1>Thermal & Power Safety</h1>
+      <p>We ensure your designs operate safely and efficiently, with correct PD negotiation, protection circuits, and thermal safeguards.</p>
+      <h2>We provide</h2>
+      <ul>
+        <li>USB-PD negotiation & compliance</li>
+        <li>Over-voltage/over-current protection</li>
+        <li>Thermal run-away detection</li>
+        <li>Power path optimisation</li>
+      </ul>
+      <p><a href="/#what-we-do">← Back to services</a></p>
+    </article>
+  )
+}

--- a/app/services/prototyping/page.js
+++ b/app/services/prototyping/page.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../../components/Breadcrumb'
+
+export const metadata = { title: 'Rapid Prototyping — TES' }
+
+export default function Page() {
+  return (
+    <article className="prose prose-neutral dark:prose-invert max-w-3xl">
+      <Breadcrumb items={[{ href: '/', label: 'Home' }, { href: '/#what-we-do', label: 'What we do' }, { label: 'Rapid Prototyping' }]} />
+      <h1>Rapid Prototyping</h1>
+      <p>We turn ideas into tested prototypes quickly, reducing your time to market and allowing faster iteration.</p>
+      <h2>Approach</h2>
+      <ul>
+        <li>Fast PCB fabrication & assembly</li>
+        <li>Fixture & jig creation</li>
+        <li>Firmware bring-up</li>
+        <li>Iterative refinement</li>
+      </ul>
+      <p><a href="/#what-we-do">← Back to services</a></p>
+    </article>
+  )
+}

--- a/components/Breadcrumb.jsx
+++ b/components/Breadcrumb.jsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Breadcrumb({ items }) {
+  return (
+    <nav className="mb-6 text-sm text-neutral-500 dark:text-neutral-400 flex gap-1 flex-wrap">
+      {items.map((item, idx) => (
+        <span key={idx} className="flex items-center gap-1">
+          {item.href ? (
+            <Link href={item.href} className="hover:text-neutral-700 dark:hover:text-neutral-200">
+              {item.label}
+            </Link>
+          ) : (
+            <span>{item.label}</span>
+          )}
+          {idx < items.length - 1 && <span>/</span>}
+        </span>
+      ))}
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- implement reusable breadcrumb component
- add dedicated service and project pages using breadcrumb navigation
- link homepage and portfolio cards to new service and project routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e0a1f16c83249dd9c2c310ef1888