### PR TITLE
feat: adjust logo for dark mode

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -9,6 +9,12 @@
       .cls-2 {
         fill: #010101;
       }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #ffffff;
+        }
+      }
     </style>
   </defs>
   <g>


### PR DESCRIPTION
## Summary
- keep logo's red accent as-is and default text to black
- add `prefers-color-scheme` media query to switch text to white in dark mode

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689656551cd48324b20d3bc22f98cd3a