### PR TITLE
feat: redesign language switcher

### DIFF
--- a/app/components/LangSwitcher.jsx
+++ b/app/components/LangSwitcher.jsx
@@ -1,38 +1,33 @@
 'use client'
 
-import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
 import { locales } from '../i18n/locales'
 
 export default function LangSwitcher({ locale, className = '' }) {
-  const [segments, setSegments] = useState([])
-  const [search, setSearch] = useState('')
-  const [hash, setHash] = useState('')
+  const router = useRouter()
+  const pathname = usePathname()
 
-  // Hydrate current URL on client (no Next navigation hooks needed)
-  useEffect(() => {
-    const { pathname, search, hash } = window.location
-    // pathname like: /en/projects/rc-bms -> keep everything after the locale
-    const parts = pathname.split('/').filter(Boolean) // ["en","projects","rc-bms"]
-    setSegments(parts.slice(1)) // ["projects","rc-bms"] or [] for homepage
-    setSearch(search || '')
-    setHash(hash || '')
-  }, [])
-
-  // SSR fallback: links point to locale home until hydrated
+  const segments = pathname.split('/').filter(Boolean).slice(1)
   const rest = segments.length ? `/${segments.join('/')}` : ''
 
+  function handleChange(e) {
+    const nextLocale = e.target.value
+    const search = window.location.search
+    const hash = window.location.hash
+    router.push(`/${nextLocale}${rest}${search}${hash}`)
+  }
+
   return (
-    <div className={className}>
-      {locales.map((l, i) => {
-        const href = `/${l}${rest}${search}${hash}`
-        const active = l === locale
-        return (
-          <Link key={l} href={href} className={`nav-link ${active ? 'font-semibold' : ''}`}>
-            {l.toUpperCase()}{i < locales.length - 1 ? ' · ' : ''}
-          </Link>
-        )
-      })}
-    </div>
+    <select
+      value={locale}
+      onChange={handleChange}
+      className={`nav-link bg-transparent ${className}`}
+    >
+      {locales.map((l) => (
+        <option key={l} value={l}>
+          {l.toUpperCase()}
+        </option>
+      ))}
+    </select>
   )
 }


### PR DESCRIPTION
## Summary
- replace flaky language switcher with dropdown that responds to route changes
- eliminate useSearchParams to avoid suspense requirement and ensure build succeeds

## Testing
- `npm test` *(fails: Missing script)*
- `npx --no-install next build`


------
https://chatgpt.com/codex/tasks/task_e_689726dd6e408324b9710c4b3fd5f325